### PR TITLE
WIP `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ exclude = ["Makefile"]
 description = "The Rust implementation of MATRIX HAL."
 license = "GPL-3.0"
 
+[features]
+default = []
+std = ["nix"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-nix = "0.16.1"
+failure = "0.1.7"
+heapless = "0.5.3"
+nix = {version = "0.16.1", optional = true}

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -1,162 +1,24 @@
 pub mod memory_map;
-use crate::{error::Error, Device};
-use memory_map::*;
-use nix::fcntl::{open, OFlag}; // https://linux.die.net/man/3/open
-use nix::sys::stat::Mode;
-use nix::unistd::close;
-use nix::{ioctl_read_bad, ioctl_write_ptr_bad};
+#[macro_use]
+use crate::{Device, with_std, without_std};
 
-// Generate ioctl_read() function
-ioctl_read_bad!(ioctl_read, ioctl_code::READ, [u8]);
-
-// Generate ioctl_write() function
-ioctl_write_ptr_bad!(ioctl_write, ioctl_code::WRITE, [u8]);
-
-/// Bridge for talking to the MATRIX Kernel Modules.
-/// Most, if not all, MATRIX functionality requires this Bus to read and write data.
-#[derive(Debug)]
-pub struct Bus {
-    /// Path for the device file being used. This is what's used to communicate with the MATRIX Kernel.
-    pub device_file: &'static str,
-    /// File descriptor for kernel abstraction.
-    pub regmap_fd: std::os::unix::io::RawFd,
-    /// Type of MATRIX device that's currently attached.
-    pub device_name: Device,
-    /// The version of the board.
-    pub device_version: u32,
-    /// Number of LEDS on the MATRIX device.
-    pub device_leds: u8,
-    /// Frequency of the FPGA on the MATRIX device.
-    pub fpga_frequency: u32,
+with_std! {
+    mod std_bus;
+    pub use std_bus::Bus as Bus;
+}
+without_std! {
+    mod no_std_bus;
+    pub use no_std_bus::Bus as Bus;
 }
 
-impl Bus {
-    /// Create, initialize, and return a MATRIX Bus
-    pub fn init() -> Result<Bus, Error> {
-        let mut bus = Bus {
-            device_file: "/dev/matrixio_regmap",
-            regmap_fd: 0,
-            device_name: Device::Unknown,
-            device_version: 0,
-            device_leds: 0,
-            fpga_frequency: 0,
-        };
+trait BusImpl {
+    fn write(&self, write_buffer: &mut [u8]);
+    fn read(&self, read_buffer: &mut [u8]);
+    fn close(&self);
 
-        // open the file descriptor to communicate with the MATRIX kernel
-        bus.regmap_fd = open(bus.device_file, OFlag::O_RDWR, Mode::empty())?;
-
-        // fetch information on the current MATRIX device
-        let (name, version) = bus.get_device_info()?;
-        bus.device_name = name;
-        bus.device_version = version;
-
-        bus.device_leds = match bus.device_name {
-            Device::Creator => device_info::MATRIX_CREATOR_LEDS,
-            Device::Voice => device_info::MATRIX_VOICE_LEDS,
-            _ => panic!("Cannot determine number of LEDs on device (This is a hard-coded value)."),
-        };
-        bus.fpga_frequency = bus.get_fpga_frequency()?;
-
-        Ok(bus)
-    }
-
-    /// Send a write buffer to the MATRIX Kernel Modules. The buffer requires an `address` to request,
-    /// the `byte_length` of the data being given, and then the rest of the data itself.
-    ///
-    /// # Usage
-    ///  ```
-    ///  let bus = matrix_rhal::Bus::init().unwrap();
-    ///
-    ///  # let address_offset = 0;
-    ///  let some_value: u16 = 237;
-    ///  let mut buffer: [u32; 3] = [0; 3];
-    ///     
-    ///  // address to query
-    ///  buffer[0] = (matrix_rhal::bus::memory_map::fpga_address::GPIO + address_offset) as u32;
-    ///  // byte length of data (u16 = 2 bytes)
-    ///  buffer[1] = 2;
-    ///  // data being sent
-    ///  buffer[2] = some_value as u32;
-    ///
-    ///  // send buffer
-    ///  bus.write(unsafe { std::mem::transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
-    ///  ```
-    pub fn write(&self, write_buffer: &mut [u8]) {
-        unsafe {
-            // TODO: error handling. Not sure if an error here would be worth recovering from.
-            ioctl_write(self.regmap_fd, write_buffer).expect("error in IOCTL WRITE");
-        }
-    }
-
-    /// Send a read buffer to the MATRIX Kernel Modules. The buffer requires an `address` to request and
-    /// the `byte_length` of what's expected to be returned. Once sent, the buffer return with populated
-    /// data.
-    ///
-    /// Keep in mind, the returned buffer will still have the `address` and `byte_length` that was passed.
-    ///
-    /// # Usage
-    ///  ```
-    ///  let bus = matrix_rhal::Bus::init().unwrap();
-    ///  let mut buffer: [u32; 4] = [0; 4];
-    ///
-    ///  // address to query
-    ///  buffer[0] = (matrix_rhal::bus::memory_map::fpga_address::CONF) as u32;
-    ///  // bytes being requested
-    ///  buffer[1] = 8;
-    ///
-    ///  // populate buffer
-    ///  bus.read(unsafe { std::mem::transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
-    ///
-    ///  // returned data will start at buffer[2]
-    ///  println!("{:?}", buffer);
-    ///  ```
-    pub fn read(&self, read_buffer: &mut [u8]) {
-        unsafe {
-            // TODO: error handling. Not sure if an error here would be worth recovering from.
-            ioctl_read(self.regmap_fd, read_buffer).expect("error in IOCTL READ");
-        }
-    }
-
-    /// Close the file descriptor that's communicating with the MATRIX Kernel's device file.
-    pub fn close(&self) {
-        close(self.regmap_fd).unwrap();
-    }
-
-    /// Return the type of MATRIX device being used and the version of the board.
-    fn get_device_info(&self) -> Result<(Device, u32), Error> {
-        // create read buffer
-        let mut data: [i32; 4] = [0; 4];
-        data[0] = fpga_address::CONF as i32;
-        data[1] = 8; // device_name(4 bytes) device_version(4 bytes)
-
-        self.read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
-        let device_name = data[2];
-        let device_version = data[3];
-
-        Ok((
-            match device_name {
-                device_info::MATRIX_CREATOR => Device::Creator,
-                device_info::MATRIX_VOICE => Device::Voice,
-                _ => return Err(Error::UnknownDevice),
-            },
-            device_version as u32,
-        ))
-    }
-
-    /// Updates the Bus to have the last known FPGA frequency of the MATRIX device.
-    fn get_fpga_frequency(&self) -> Result<u32, Error> {
-        // create read buffer
-        let mut data: [i32; 3] = [0; 3];
-        data[0] = (fpga_address::CONF + 4) as i32;
-        data[1] = 4; // value0(2 bytes) value1(2bytes) // TODO: ask what these values represent
-
-        self.read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
-
-        // extract both u16 numbers from u32
-        let value0 = data[2] >> 16; // store 1st 16 bits
-        let value1 = !(value0 << 16) & data[2]; // store 2nd 16 bits
-        let frequency = (device_info::FPGA_CLOCK * value0 as u32) / value1 as u32;
-
-        Ok(frequency)
-    }
+    fn device_name(&self) -> Device;
+    fn device_version(&self) -> u32;
+    fn device_leds(&self) -> u8;
+    fn fpga_frequency(&self) -> u32;
 }
+

--- a/src/bus/no_std_bus.rs
+++ b/src/bus/no_std_bus.rs
@@ -1,0 +1,33 @@
+use crate::{bus::memory_map::*, error::Error, Device};
+use super::BusImpl;
+
+#[derive(Debug)]
+pub struct Bus {
+}
+
+impl Bus {
+    pub fn init() -> Result<Bus, Error> {
+        unimplemented!()
+    }
+    pub fn device_name(&self) -> Device {
+        unimplemented!()
+    }
+    pub fn device_version(&self) -> u32 {
+        unimplemented!()
+    }
+    pub fn device_leds(&self) -> u8 {
+        unimplemented!()
+    }
+    pub fn fpga_frequency(&self) -> u32 {
+        unimplemented!()
+    }
+    pub fn write(&self, write_buffer: &mut [u8]) {
+        unimplemented!()
+    }
+    pub fn read(&self, read_buffer: &mut [u8]) {
+        unimplemented!()
+    }
+    pub fn close(&self) {
+        unimplemented!()
+    }
+}

--- a/src/bus/std_bus.rs
+++ b/src/bus/std_bus.rs
@@ -1,0 +1,174 @@
+use crate::{bus::memory_map::*, error::Error, Device};
+use super::BusImpl;
+use nix::fcntl::{open, OFlag}; // https://linux.die.net/man/3/open
+use nix::sys::stat::Mode;
+use nix::unistd::close;
+use nix::{ioctl_read_bad, ioctl_write_ptr_bad};
+
+// Generate ioctl_read() function
+ioctl_read_bad!(ioctl_read, ioctl_code::READ, [u8]);
+
+// Generate ioctl_write() function
+ioctl_write_ptr_bad!(ioctl_write, ioctl_code::WRITE, [u8]);
+
+/// Bridge for talking to the MATRIX Kernel Modules.
+/// Most, if not all, MATRIX functionality requires this Bus to read and write data.
+#[derive(Debug)]
+pub struct Bus {
+    /// Path for the device file being used. This is what's used to communicate with the MATRIX Kernel.
+    device_file: &'static str,
+    /// File descriptor for kernel abstraction.
+    regmap_fd: std::os::unix::io::RawFd,
+    /// Type of MATRIX device that's currently attached.
+    device_name: Device,
+    /// The version of the board.
+    device_version: u32,
+    /// Number of LEDS on the MATRIX device.
+    device_leds: u8,
+    /// Frequency of the FPGA on the MATRIX device.
+    fpga_frequency: u32,
+}
+
+impl Bus {
+    /// Create, initialize, and return a MATRIX Bus
+    pub fn init() -> Result<Bus, Error> {
+        let mut bus = Bus {
+            device_file: "/dev/matrixio_regmap",
+            regmap_fd: 0,
+            device_name: Device::Unknown,
+            device_version: 0,
+            device_leds: 0,
+            fpga_frequency: 0,
+        };
+
+        // open the file descriptor to communicate with the MATRIX kernel
+        bus.regmap_fd = open(bus.device_file, OFlag::O_RDWR, Mode::empty())?;
+
+        // fetch information on the current MATRIX device
+        let (name, version) = bus.get_device_info()?;
+        bus.device_name = name;
+        bus.device_version = version;
+
+        bus.device_leds = match bus.device_name {
+            Device::Creator => device_info::MATRIX_CREATOR_LEDS,
+            Device::Voice => device_info::MATRIX_VOICE_LEDS,
+            _ => panic!("Cannot determine number of LEDs on device (This is a hard-coded value)."),
+        };
+        bus.fpga_frequency = bus.get_fpga_frequency()?;
+
+        Ok(bus)
+    }
+
+    pub fn device_name(&self) -> Device {
+        self.device_name
+    }
+    pub fn device_version(&self) -> u32 {
+        self.device_version
+    }
+    pub fn device_leds(&self) -> u8 {
+        self.device_leds
+    }
+    pub fn fpga_frequency(&self) -> u32 {
+        self.fpga_frequency
+    }
+
+    /// Send a write buffer to the MATRIX Kernel Modules. The buffer requires an `address` to request,
+    /// the `byte_length` of the data being given, and then the rest of the data itself.
+    ///
+    /// # Usage
+    ///  ```
+    ///  let bus = matrix_rhal::Bus::init().unwrap();
+    ///
+    ///  # let address_offset = 0;
+    ///  let some_value: u16 = 237;
+    ///  let mut buffer: [u32; 3] = [0; 3];
+    ///     
+    ///  // address to query
+    ///  buffer[0] = (matrix_rhal::bus::memory_map::fpga_address::GPIO + address_offset) as u32;
+    ///  // byte length of data (u16 = 2 bytes)
+    ///  buffer[1] = 2;
+    ///  // data being sent
+    ///  buffer[2] = some_value as u32;
+    ///
+    ///  // send buffer
+    ///  bus.write(unsafe { std::mem::transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
+    ///  ```
+    pub fn write(&self, write_buffer: &mut [u8]) {
+        unsafe {
+            // TODO: error handling. Not sure if an error here would be worth recovering from.
+            ioctl_write(self.regmap_fd, write_buffer).expect("error in IOCTL WRITE");
+        }
+    }
+
+    /// Send a read buffer to the MATRIX Kernel Modules. The buffer requires an `address` to request and
+    /// the `byte_length` of what's expected to be returned. Once sent, the buffer return with populated
+    /// data.
+    ///
+    /// Keep in mind, the returned buffer will still have the `address` and `byte_length` that was passed.
+    ///
+    /// # Usage
+    ///  ```
+    ///  let bus = matrix_rhal::Bus::init().unwrap();
+    ///  let mut buffer: [u32; 4] = [0; 4];
+    ///
+    ///  // address to query
+    ///  buffer[0] = (matrix_rhal::bus::memory_map::fpga_address::CONF) as u32;
+    ///  // bytes being requested
+    ///  buffer[1] = 8;
+    ///
+    ///  // populate buffer
+    ///  bus.read(unsafe { std::mem::transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
+    ///
+    ///  // returned data will start at buffer[2]
+    ///  println!("{:?}", buffer);
+    ///  ```
+    pub fn read(&self, read_buffer: &mut [u8]) {
+        unsafe {
+            // TODO: error handling. Not sure if an error here would be worth recovering from.
+            ioctl_read(self.regmap_fd, read_buffer).expect("error in IOCTL READ");
+        }
+    }
+
+    /// Close the file descriptor that's communicating with the MATRIX Kernel's device file.
+    pub fn close(&self) {
+        close(self.regmap_fd).unwrap();
+    }
+
+    /// Return the type of MATRIX device being used and the version of the board.
+    fn get_device_info(&self) -> Result<(Device, u32), Error> {
+        // create read buffer
+        let mut data: [i32; 4] = [0; 4];
+        data[0] = fpga_address::CONF as i32;
+        data[1] = 8; // device_name(4 bytes) device_version(4 bytes)
+
+        self.read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
+        let device_name = data[2];
+        let device_version = data[3];
+
+        Ok((
+            match device_name {
+                device_info::MATRIX_CREATOR => Device::Creator,
+                device_info::MATRIX_VOICE => Device::Voice,
+                _ => return Err(Error::UnknownDevice),
+            },
+            device_version as u32,
+        ))
+    }
+
+    /// Updates the Bus to have the last known FPGA frequency of the MATRIX device.
+    fn get_fpga_frequency(&self) -> Result<u32, Error> {
+        // create read buffer
+        let mut data: [i32; 3] = [0; 3];
+        data[0] = (fpga_address::CONF + 4) as i32;
+        data[1] = 4; // value0(2 bytes) value1(2bytes) // TODO: ask what these values represent
+
+        self.read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
+
+        // extract both u16 numbers from u32
+        let value0 = data[2] >> 16; // store 1st 16 bits
+        let value1 = !(value0 << 16) & data[2]; // store 2nd 16 bits
+        let frequency = (device_info::FPGA_CLOCK * value0 as u32) / value1 as u32;
+
+        Ok(frequency)
+    }
+}

--- a/src/everloop/led.rs
+++ b/src/everloop/led.rs
@@ -24,6 +24,6 @@ impl Rgbw {
     }
 
     pub fn as_bytes(self) -> i32 {
-        unsafe { std::mem::transmute::<Rgbw, i32>(self) }
+        i32::from_be_bytes([self.r, self.g, self.b, self.w])
     }
 }

--- a/src/gpio/config.rs
+++ b/src/gpio/config.rs
@@ -15,7 +15,7 @@ pub enum Mode {
 
 impl PinConfig for Mode {
     fn update_pin_map(&self, pin: u8, gpio: &Gpio) -> Result<(u16, u16), Error> {
-        let pin_map = &mut *gpio.mode_pin_map.lock()?;
+        let pin_map = gpio.mode_pin_map.get_mut();
         Ok((set_pin_config(pin, *self as u16, pin_map), 0))
     }
 }
@@ -29,7 +29,7 @@ pub enum State {
 
 impl PinConfig for State {
     fn update_pin_map(&self, pin: u8, gpio: &Gpio) -> Result<(u16, u16), Error> {
-        let pin_map = &mut *gpio.state_pin_map.lock()?;
+        let pin_map = gpio.state_pin_map.get_mut();
         Ok((set_pin_config(pin, *self as u16, pin_map), 1))
     }
 }
@@ -43,7 +43,7 @@ pub enum Function {
 
 impl PinConfig for Function {
     fn update_pin_map(&self, pin: u8, gpio: &Gpio) -> Result<(u16, u16), Error> {
-        let pin_map = &mut *gpio.function_pin_map.lock()?;
+        let pin_map = gpio.function_pin_map.get_mut();
         Ok((set_pin_config(pin, *self as u16, pin_map), 2))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod bus;
 mod error;
 mod everloop;
@@ -11,8 +13,13 @@ pub use everloop::Rgbw;
 pub use gpio::Gpio;
 pub use sensors::Sensors;
 
+#[macro_export]
+macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std")]$i)*) }
+#[macro_export]
+macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std"))]$i)*) }
+
 /// The Different types of MATRIX Devices
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Device {
     /// MATRIX Creator.

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -2,6 +2,7 @@ use crate::bus::memory_map::*;
 use crate::{Bus, Device};
 mod data;
 use data::*;
+use core::intrinsics::transmute;
 
 /// Communicates with the main sensors on the MATRIX Creator.
 #[derive(Debug)]
@@ -13,7 +14,7 @@ pub struct Sensors<'a> {
 impl<'a> Sensors<'a> {
     /// Creates a new instance of Sensors.
     pub fn new(bus: &Bus) -> Sensors {
-        if bus.device_name != Device::Creator {
+        if bus.device_name() != Device::Creator {
             panic!("Sensors are only available on the MATRIX Creator!")
         }
 
@@ -31,7 +32,7 @@ impl<'a> Sensors<'a> {
 
         // populate buffer
         self.bus
-            .read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
+            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
 
         data[2] as f32 / 1000.0
     }
@@ -47,7 +48,7 @@ impl<'a> Sensors<'a> {
 
         // populate buffer
         self.bus
-            .read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
+            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
 
         Pressure {
             pressure: data[3] as f32 / 1000.0,
@@ -67,7 +68,7 @@ impl<'a> Sensors<'a> {
 
         // populate buffer
         self.bus
-            .read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
+            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
 
         Humidity {
             humidity: data[2] as f32 / 1000.0,
@@ -86,7 +87,7 @@ impl<'a> Sensors<'a> {
 
         // populate read buffer
         self.bus
-            .read(unsafe { std::mem::transmute::<&mut [i32], &mut [u8]>(&mut data) });
+            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
 
         Imu {
             accel_x: data[2] as f32 / 1000.0,


### PR DESCRIPTION
I'm mostly interested in working on bare-metal Matrix Voice w/ ESP32.  This PR contains some initial changes to move in that direction.

I see some work is being done on the wishbone bus implementation so the goal is to:
1. Convey my intents wrt `no_std` Rust to avoid conflicts
1. Get feedback regarding future direction for lib, etc.
1. Discuss replacing `gpio::Gpio` field `banks: Mutex<Vec<Bank<'a>>>` with something that doesn't require a mutex

Contentious changes:
- As per [embedded book](https://docs.rust-embedded.org/book/collections/); can either use `alloc` or alternative like `heapless`.  Here I'm using [heapless](https://crates.io/crates/heapless)
- Replace `std::error` (which doesn't support no_std) with [failure](https://github.com/withoutboats/failure) (which does)
- Replace `std::mem::transmute` with `core::intrinsics::transmute`
- In `gpio/mod.rs`, replace `std::sync::Mutex` with `core::sync::atomic`

When connected to Rpi GPIO can just compile with `cargo build`.  To build for ESP32, `cargo build --no-default-features` (which currently doesn't compile because of `banks` field in `gpio::Gpio`.