### PR TITLE
Simplified MatrixBus API

### DIFF
--- a/examples/esp32_everloop/Cargo.toml
+++ b/examples/esp32_everloop/Cargo.toml
@@ -10,4 +10,4 @@ cty = "0.2"
 esp-idf-sys = "0.1.2"
 
 [build-dependencies]
-esp_idf_build = "0.1"
+esp_idf_build = ">= 0.1.0, < 0.1.1"

--- a/src/bus/esp/bus.rs
+++ b/src/bus/esp/bus.rs
@@ -188,19 +188,12 @@ fn spi_address_bytes(address: u16, readnwrite: bool) -> HardwareAddress {
 }
 
 impl MatrixBus for Bus {
-    fn write(&self, write_buffer: &mut [u8]) {
-        // Unpack the write address from the first 32-bits
-        let buffer_u32 = unsafe { core::intrinsics::transmute::<&mut [u8], &mut [u32]>(write_buffer) };
-        let address = u16::try_from(buffer_u32[0]).unwrap();
-        // Write actual data to the address
-        self.write_address(address, &write_buffer[crate::MATRIXBUS_HEADER_BYTES..])
+    fn write(&self, address: u16, write_buffer: &[u8]) {
+        self.write_address(address, write_buffer)
     }
 
-    fn read(&self, read_buffer: &mut [u8]) {
-        // Unpack the read address from the first 32-bits
-        let buffer_u32 = unsafe { core::intrinsics::transmute::<&mut [u8], &mut [u32]>(read_buffer) };
-        let address = u16::try_from(buffer_u32[0]).unwrap();
-        self.read_address(address, &mut read_buffer[crate::MATRIXBUS_HEADER_BYTES..])
+    fn read(&self, address: u16, read_buffer: &mut [u8]) {
+        self.read_address(address, read_buffer)
     }
 
     fn close(&self) {

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -33,7 +33,7 @@ pub trait MatrixBus {
     ///  // send buffer
     ///  bus.write(unsafe { std::mem::transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
     ///  ```
-    fn write(&self, write_buffer: &mut [u8]);
+    fn write(&self, address: u16, write_buffer: &[u8]);
 
     /// Send a read buffer to the MATRIX Bus. The buffer requires an `address` to request and
     /// the `byte_length` of what's expected to be returned. Once sent, the buffer return with populated
@@ -57,7 +57,7 @@ pub trait MatrixBus {
     ///  // returned data will start at buffer[2]
     ///  println!("{:?}", buffer);
     ///  ```
-    fn read(&self, read_buffer: &mut [u8]);
+    fn read(&self, address: u16, read_buffer: &mut [u8]);
 
     /// If possible, close the connection to the MATRIX Bus.
     fn close(&self);

--- a/src/bus/std_bus/direct/mod.rs
+++ b/src/bus/std_bus/direct/mod.rs
@@ -68,15 +68,17 @@ impl Bus {
 }
 
 impl MatrixBus for Bus {
-    fn write(&self, write_buffer: &mut [u8]) {
+    fn write(&self, address: u16, write_buffer: &[u8]) {
         unsafe {
             // TODO: ....
+            unimplemented!()
         }
     }
 
-    fn read(&self, read_buffer: &mut [u8]) {
+    fn read(&self, address: u16, read_buffer: &mut [u8]) {
         unsafe {
             // TODO: ....
+            unimplemented!()
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,9 @@ pub enum Error {
     /// ESP-IDF call failed.
     #[cfg(not(feature = "std"))]
     #[fail(display = "esp-idf error: {}", error)]
-    EspIdf { error: crate::bus::esp::error::EspError },
+    EspIdf {
+        error: crate::bus::esp::error::EspError,
+    },
 }
 
 with_std! {

--- a/src/gpio/bank.rs
+++ b/src/gpio/bank.rs
@@ -1,6 +1,5 @@
-use crate::bus::memory_map::*;
-use crate::bus::MatrixBus;
-use core::intrinsics::transmute;
+use crate::as_u8_slice;
+use crate::bus::{memory_map::*, MatrixBus};
 
 /// Bank contains functions to configure a PWM.
 /// A bank is a set of 4 pins, starting from pin 0 and going in order.
@@ -59,12 +58,8 @@ impl<'a> Bank<'a> {
     /// Send a bank configuration to the MATRIX bus.
     fn bus_write(&self, memory_offset: u16, timer_setup: u16) {
         // create and populate write buffer
-        let mut buffer: [u32; 3] = [0; 3];
-        buffer[0] = (memory_offset) as u32; // address to write to
-        buffer[1] = 2; // byte length of timer_setup
-        buffer[2] = timer_setup as u32;
+        let buffer = [timer_setup; 1];
 
-        self.bus
-            .write(unsafe { transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
+        self.bus.write(memory_offset, as_u8_slice(&buffer));
     }
 }

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -1,11 +1,9 @@
-use crate::bus::MatrixBus;
-use crate::Error;
+use crate::bus::{memory_map::*, MatrixBus};
+use crate::{as_mut_u8_slice, as_u8_slice, Error};
 pub mod bank;
 pub mod config;
-use crate::bus::memory_map::*;
 pub use bank::*;
 pub use config::*;
-use core::intrinsics::transmute;
 use core::sync::atomic::{AtomicU16, Ordering};
 
 /// Controls the GPIO pins on a MATRIX device.
@@ -56,14 +54,14 @@ impl<'a> Gpio<'a> {
         Gpio::is_pin_valid(pin).unwrap();
 
         // create read buffer
-        let mut data: [u32; 3] = [0; 3];
+        let mut data = [0u16; 1];
 
         // update read buffer
-        self.bus_read(&mut data, 2, 1); // all pin states are encoded as a single u16. 2 bytes needed (8*2 = 16 pins)
+        self.bus_read(&mut data, 1); // all pin states are encoded as a single u16. 2 bytes needed (8*2 = 16 pins)
 
         // bit operation to extract the current pin's state
         let mask = 0x1 << pin;
-        let state = (data[2] & mask) >> pin;
+        let state = (data[0] & mask) >> pin;
 
         match state {
             0 => false,
@@ -78,16 +76,16 @@ impl<'a> Gpio<'a> {
     /// Returns the current digital value of every MATRIX GPIO pin (0->15)
     pub fn get_states(&self) -> [bool; 16] {
         // create read buffer
-        let mut data: [u32; 3] = [0; 3];
+        let mut data = [0u16; 1];
 
         // update read buffer
-        self.bus_read(&mut data, 2, 1); // all pin states are encoded as a single u16. 2 bytes needed (8*2 = 16 pins)
+        self.bus_read(&mut data, 1); // all pin states are encoded as a single u16. 2 bytes needed (8*2 = 16 pins)
 
         // bit operation to extract each pin state (0-15)
         let mut pins: [bool; 16] = [false; 16];
         for i in 0..16 {
             let mask = 0x1 << i;
-            let state = ((data[2] & mask) >> i) as u8;
+            let state = ((data[0] & mask) >> i) as u8;
 
             pins[i] = match state {
                 0 => false,
@@ -102,16 +100,11 @@ impl<'a> Gpio<'a> {
     }
 
     /// Shortener to populate a read buffer, through `bus.read`, for GPIO pin information.
-    fn bus_read(&self, buffer: &mut [u32], buffer_length: u32, address_offset: u16) {
-        // address to query
-        buffer[0] = (fpga_address::GPIO + address_offset) as u32;
-        // size of expected data (bytes)
-        buffer[1] = buffer_length;
-
+    fn bus_read(&self, buffer: &mut [u16], address_offset: u16) {
         // populate buffer
         // the buffer will be passed a value that contains the state of each GPIO pin
         self.bus
-            .read(unsafe { transmute::<&mut [u32], &mut [u8]>(buffer) });
+            .read(fpga_address::GPIO + address_offset, as_mut_u8_slice(buffer));
     }
 }
 
@@ -150,13 +143,10 @@ impl<'a> Gpio<'a> {
 
     /// Shortener to send pin configurations through `bus.write`.
     fn bus_write(&self, value: u16, address_offset: u16) {
-        let mut buffer: [u32; 3] = [0; 3];
-        buffer[0] = (fpga_address::GPIO + address_offset) as u32; // address to write to
-        buffer[1] = 2; // byte length of u16 value
-        buffer[2] = value as u32;
+        let buffer = [value; 1];
 
         self.bus
-            .write(unsafe { transmute::<&mut [u32], &mut [u8]>(&mut buffer) });
+            .write(fpga_address::GPIO + address_offset, as_u8_slice(&buffer));
     }
 
     /// Set the prescaler value for a specific bank

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,17 +1,14 @@
 use crate::bus::{memory_map::*, MatrixBus};
-use crate::{Device, Error};
-use core::intrinsics::transmute;
+use crate::{as_mut_u8_slice, Device, Error};
 
 /// Return the type of MATRIX device being used and the version of the board.
 pub fn get_device_info(bus: &dyn MatrixBus) -> Result<(Device, u32), Error> {
     // create read buffer
-    let mut data: [i32; 4] = [0; 4];
-    data[0] = fpga_address::CONF as i32;
-    data[1] = 8; // device_name(4 bytes) device_version(4 bytes)
+    let mut data = [0i32; 2]; // device_name(4 bytes) device_version(4 bytes)
 
-    bus.read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
-    let device_name = data[2];
-    let device_version = data[3];
+    bus.read(fpga_address::CONF, as_mut_u8_slice(&mut data));
+    let device_name = data[0];
+    let device_version = data[1];
 
     Ok((
         match device_name {
@@ -26,16 +23,12 @@ pub fn get_device_info(bus: &dyn MatrixBus) -> Result<(Device, u32), Error> {
 /// Updates the Bus to have the last known FPGA frequency of the MATRIX device.
 pub fn get_fpga_frequency(bus: &dyn MatrixBus) -> Result<u32, Error> {
     // create read buffer
-    let mut data: [i32; 3] = [0; 3];
-    data[0] = (fpga_address::CONF + 4) as i32;
-    data[1] = 4; // value0(2 bytes) value1(2bytes) // TODO: ask what these values represent
+    let mut data = [0u16; 2]; // value0(2 bytes) value1(2bytes) // TODO: ask what these values represent
+    bus.read(fpga_address::CONF + 4, as_mut_u8_slice(&mut data));
 
-    bus.read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
-
-    // extract both u16 numbers from u32
-    let value0 = data[2] >> 16; // store 1st 16 bits
-    let value1 = !(value0 << 16) & data[2]; // store 2nd 16 bits
-    let frequency = (device_info::FPGA_CLOCK * value0 as u32) / value1 as u32;
+    let value0 = data[0] as u32; // store 1st 16 bits
+    let value1 = data[1] as u32; // store 2nd 16 bits
+    let frequency = (device_info::FPGA_CLOCK * value0) / value1;
 
     Ok(frequency)
 }

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -1,7 +1,6 @@
 use crate::bus::{memory_map::*, MatrixBus};
-use crate::Device;
+use crate::{as_mut_u8_slice, Device};
 mod data;
-use core::intrinsics::transmute;
 use data::*;
 
 /// Communicates with the main sensors on the MATRIX Creator.
@@ -22,94 +21,73 @@ impl<'a> Sensors<'a> {
 
     /// Return the latest UV sensor value.
     pub fn read_uv(&self) -> f32 {
-        const BUFFER_LENGTH: usize = get_buffer_length(UV_BYTES);
-
         // create read buffer
-        let mut data: [i32; BUFFER_LENGTH] = [0; BUFFER_LENGTH];
-        data[0] = (fpga_address::MCU + (mcu_offset::UV >> 1)) as i32;
-        data[1] = UV_BYTES;
-
+        let mut data = [0i32; get_buffer_length(UV_BYTES)];
+        let address = fpga_address::MCU + (mcu_offset::UV >> 1);
         // populate buffer
-        self.bus
-            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
-
-        data[2] as f32 / 1000.0
+        self.bus.read(address, as_mut_u8_slice(&mut data));
+        data[0] as f32 / 1000.0
     }
 
     /// Return the latest Pressure sensor values.
     pub fn read_pressure(&self) -> Pressure {
-        const BUFFER_LENGTH: usize = get_buffer_length(PRESSURE_BYTES);
-
         // create read buffer
-        let mut data: [i32; BUFFER_LENGTH] = [0; BUFFER_LENGTH];
-        data[0] = (fpga_address::MCU + (mcu_offset::PRESSURE >> 1)) as i32;
-        data[1] = PRESSURE_BYTES;
+        let mut data = [0i32; get_buffer_length(PRESSURE_BYTES)];
 
+        let address = fpga_address::MCU + (mcu_offset::PRESSURE >> 1);
         // populate buffer
-        self.bus
-            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
-
+        self.bus.read(address, as_mut_u8_slice(&mut data));
         Pressure {
-            pressure: data[3] as f32 / 1000.0,
-            altitude: data[2] as f32 / 1000.0,
-            temperature: data[4] as f32 / 1000.0,
+            pressure: data[1] as f32 / 1000.0,
+            altitude: data[0] as f32 / 1000.0,
+            temperature: data[2] as f32 / 1000.0,
         }
     }
 
     /// Return the latest Humidity sensor values.
     pub fn read_humidity(&self) -> Humidity {
-        const BUFFER_LENGTH: usize = get_buffer_length(HUMIDITY_BYTES);
-
         // create read buffer
-        let mut data: [i32; BUFFER_LENGTH] = [0; BUFFER_LENGTH];
-        data[0] = (fpga_address::MCU + (mcu_offset::HUMIDITY >> 1)) as i32;
-        data[1] = HUMIDITY_BYTES;
-
+        let mut data = [0i32; get_buffer_length(HUMIDITY_BYTES)];
+        let address = fpga_address::MCU + (mcu_offset::HUMIDITY >> 1);
         // populate buffer
-        self.bus
-            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
-
+        self.bus.read(address, as_mut_u8_slice(&mut data));
         Humidity {
-            humidity: data[2] as f32 / 1000.0,
-            temperature: data[3] as f32 / 1000.0,
+            humidity: data[0] as f32 / 1000.0,
+            temperature: data[1] as f32 / 1000.0,
         }
     }
 
     /// Return the latest IMU sensor values.
     pub fn read_imu(&self) -> Imu {
-        const BUFFER_LENGTH: usize = get_buffer_length(IMU_BYTES);
-
         // create read buffer
-        let mut data: [i32; BUFFER_LENGTH] = [0; BUFFER_LENGTH];
-        data[0] = (fpga_address::MCU + (mcu_offset::IMU >> 1)) as i32;
-        data[1] = IMU_BYTES;
+        let mut data = [0i32; get_buffer_length(IMU_BYTES)];
 
+        let address = fpga_address::MCU + (mcu_offset::IMU >> 1);
         // populate read buffer
-        self.bus
-            .read(unsafe { transmute::<&mut [i32], &mut [u8]>(&mut data) });
+        self.bus.read(address, as_mut_u8_slice(&mut data));
 
         Imu {
-            accel_x: data[2] as f32 / 1000.0,
-            accel_y: data[3] as f32 / 1000.0,
-            accel_z: data[4] as f32 / 1000.0,
+            accel_x: data[0] as f32 / 1000.0,
+            accel_y: data[1] as f32 / 1000.0,
+            accel_z: data[2] as f32 / 1000.0,
 
-            gyro_x: data[5] as f32 / 1000.0,
-            gyro_y: data[6] as f32 / 1000.0,
-            gyro_z: data[7] as f32 / 1000.0,
+            gyro_x: data[3] as f32 / 1000.0,
+            gyro_y: data[4] as f32 / 1000.0,
+            gyro_z: data[5] as f32 / 1000.0,
 
-            mag_x: data[8] as f32 / 1000.0,
-            mag_y: data[9] as f32 / 1000.0,
-            mag_z: data[10] as f32 / 1000.0,
+            mag_x: data[6] as f32 / 1000.0,
+            mag_y: data[7] as f32 / 1000.0,
+            mag_z: data[9] as f32 / 1000.0,
 
             // TODO: ask why we have these. They seem to be unused.
-            mag_offset_x: data[11] as f32,
-            mag_offset_y: data[12] as f32,
-            mag_offset_z: data[13] as f32,
+            mag_offset_x: data[9] as f32,
+            mag_offset_y: data[10] as f32,
+            mag_offset_z: data[11] as f32,
 
             // These values are already floats so we just need to treat them as one.
-            yaw: f32::from_bits(data[14] as u32),
-            pitch: f32::from_bits(data[15] as u32),
-            roll: f32::from_bits(data[16] as u32),
+            yaw: f32::from_bits(data[12] as u32),
+            pitch: f32::from_bits(data[13] as u32),
+            roll: f32::from_bits(data[14] as u32),
         }
     }
 }
@@ -117,8 +95,6 @@ impl<'a> Sensors<'a> {
 /// Calculate the size a read buffer needs to be for a sensor.
 ///
 /// Since all sensor's values are a byte each, we can divide it by 4 to see how many values need to be stored.
-///
-/// 2 is added to make room for the `address` and `byte_length` of `bus.read`.
 const fn get_buffer_length(sensor_bytes: i32) -> usize {
-    (sensor_bytes / 4 + 2) as usize
+    (sensor_bytes / 4) as usize
 }


### PR DESCRIPTION
- Move address parameter to MatrixBus trait, impls are now responsible for packing/formatting as required by the platform
- esp32_everloop example uses ESP-IDF v3.3 and must use older esp_idf_build
- Tested on Voice using kernel module and ESP32